### PR TITLE
Fix bot mode hang on WiFi connection (closes #5)

### DIFF
--- a/chess_bot.cpp
+++ b/chess_bot.cpp
@@ -260,6 +260,16 @@ bool ChessBot::connectToWiFi() {
         return false;
     }
     
+    // Tear down AP mode (set up by WiFiManager during setup) before switching to STA mode.
+    // WiFiNINA on the Arduino Nano RP2040 Connect / Nano 33 IoT / MKR WiFi 1010 cannot run
+    // AP and STA simultaneously. If the AP is left active, WiFi.begin() silently hangs and
+    // the bot mode appears frozen after "Connecting to WiFi..." with no further output.
+    // See: https://github.com/Concept-Bytes/Open-Chess/issues/5
+    Serial.println("Tearing down AP mode before connecting as station...");
+    WiFi.disconnect();
+    WiFi.end();
+    delay(2000);
+    
     Serial.print("Attempting to connect to SSID: ");
     Serial.println(SECRET_SSID);
     


### PR DESCRIPTION
## Problem

When the user selects the **Chess Bot (Human vs AI)** mode, the board hangs after `Connecting to WiFi...` with no further serial output. After ~50s the failure animation runs (board flashes red 5x) as if the WiFi credentials were wrong, but they are correct — same SSID/password works for any other client.

This matches the symptoms reported in #5 exactly:
```
Making API request to Stockfish...
Failed to connect to Stockfish API
```

## Root cause

`WiFiManager::begin()` runs in `setup()` and puts the WiFiNINA module into **AP mode** (`OpenChessBoard` / `chess123`) so the user can pick a game mode from a browser. When the user later picks the bot mode on the physical board, `ChessBot::connectToWiFi()` immediately calls `WiFi.begin(SECRET_SSID, SECRET_PASS)` to switch to STA mode.

WiFiNINA on the Arduino Nano RP2040 Connect (and the Nano 33 IoT / MKR WiFi 1010) **cannot run AP and STA simultaneously**. With the AP still listening, `WiFi.begin()` silently never reaches `WL_CONNECTED`, the 10×5s retry loop times out, and the bot mode dies.

## Fix

Explicitly tear the AP down before opening the STA connection:

```cpp
WiFi.disconnect();
WiFi.end();
delay(2000);
```

Then proceed with `WiFi.begin()` as before. `WiFi.end()` releases the radio cleanly and `delay(2000)` lets the WiFiNINA firmware finish reinitialising before the next mode change.

## Verification

Tested on **Arduino Nano RP2040 Connect** with **WiFiNINA firmware 3.0.1** and the official `OpenChess.ino` (with `#define ENABLE_WIFI`):

```
=== Starting Chess Bot Mode ===
Bot Difficulty: Medium (Depth 10)
Connecting to WiFi...
Tearing down AP mode before connecting as station...
Attempting to connect to SSID: <my-ssid>
Connection attempt 1/10 - Status: 3
Connected to WiFi!
IP address: 192.168.0.99
WiFi connected! Bot mode ready.
...
Making API request to Stockfish...
=== RAW API RESPONSE ===
{"success":true,"evaluation":0.12,"mate":null,"bestmove":"bestmove d7d5 ponder a2a4",...}
Bot move: d7d5
```

Bot connects on the first attempt, Stockfish API responds, gameplay proceeds normally.

## Trade-offs

- **+10 lines, 1 file** (`chess_bot.cpp`)
- The `OpenChessBoard` AP is no longer reachable once bot mode starts. This is unavoidable on WiFiNINA hardware and matches user expectation: once a mode is picked, the AP is no longer needed.
- No behavioural change in non-bot modes.