### PR TITLE
Phase 2 + 3: full chess rules + UX polish for RP2040 (with self-tests)

### DIFF
--- a/OpenChess.ino
+++ b/OpenChess.ino
@@ -100,6 +100,24 @@ void setup() {
   boardDriver.begin();
   Serial.println("DEBUG: Board driver initialized successfully");
 
+  // Run chess engine self-tests early. These are pure C++, do not touch
+  // hardware, and finish in <100ms. If a fix breaks the engine we want
+  // to see it in the serial monitor before WiFi setup eats 10+ seconds.
+  int testFailures = chessEngine.runSelfTests();
+  if (testFailures > 0) {
+    Serial.print("WARNING: ");
+    Serial.print(testFailures);
+    Serial.println(" engine self-tests FAILED. Gameplay may be incorrect!");
+    // Flash red briefly to signal the failure to the user
+    for (int i = 0; i < 5; i++) {
+      for (int r = 0; r < 8; r++)
+        for (int c = 0; c < 8; c++)
+          boardDriver.setSquareLED(r, c, 255, 0, 0, 0);
+      boardDriver.showLEDs(); delay(150);
+      boardDriver.clearAllLEDs(); delay(150);
+    }
+  }
+
 #ifdef ENABLE_WIFI
   Serial.println();
   Serial.println("=== WiFi Mode Enabled ===");
@@ -313,6 +331,18 @@ void handleGameSelection() {
 }
 
 void initializeSelectedMode(GameMode mode) {
+  // Shut down the WiFiManager AP for modes that don't need WiFi.
+  // The AP draws ~100mA continuously and creates a visible network
+  // ("OpenChessBoard") that nobody uses once a mode is picked. The
+  // bot mode tears down + reopens WiFi as a station internally
+  // (see PR #9), so we leave it alone for that path.
+#ifdef ENABLE_WIFI
+  if (mode == MODE_CHESS_MOVES || mode == MODE_SENSOR_TEST || mode == MODE_GAME_3) {
+    Serial.println("Shutting down WiFi AP - not needed for this mode.");
+    WiFi.end();
+    delay(500);
+  }
+#endif
   switch (mode) {
     case MODE_CHESS_MOVES:
       Serial.println("Starting Chess Moves (Human vs Human)...");

--- a/OpenChess.ino
+++ b/OpenChess.ino
@@ -4,6 +4,15 @@
 #include "sensor_test.h"
 #include "chess_bot.h"
 
+// ---------------------------
+// Firmware version
+// ---------------------------
+// Bumped by the semichcsc-byte/Open-Chess RP2040 fix-fork. Kept separate
+// from any upstream Concept-Bytes versioning. Format: vMAJOR.MINOR.PATCH
+// for the fork, with -rp2040 suffix to make it obvious this is the
+// patched build that targets the Arduino Nano RP2040 Connect.
+#define OPENCHESS_FW_VERSION "1.0.0-rp2040"
+
 // Uncomment the next line to enable WiFi features (requires compatible board)
 #define ENABLE_WIFI  // Currently disabled - RP2040 boards use local mode only
 #ifdef ENABLE_WIFI
@@ -71,6 +80,9 @@ void setup() {
   Serial.println();
   Serial.println("================================================");
   Serial.println("         OpenChess Starting Up");
+  Serial.print  ("         Firmware: v");
+  Serial.println(OPENCHESS_FW_VERSION);
+  Serial.println("         Fork:    semichcsc-byte/Open-Chess");
   Serial.println("================================================");
   Serial.println("DEBUG: Serial communication established");
   Serial.print("DEBUG: Millis since boot: ");

--- a/OpenChess.ino
+++ b/OpenChess.ino
@@ -328,8 +328,17 @@ void initializeSelectedMode(GameMode mode) {
       break;
     case MODE_GAME_3:
       Serial.println("This game mode will be available in a future update!");
-      Serial.println("Returning to game selection in 3 seconds...");
-      delay(3000);
+      Serial.println("Returning to game selection - please remove the piece from the placeholder square.");
+      // Wait for the piece to be lifted off the placeholder square so the
+      // selection loop doesn't immediately re-trigger this branch on every
+      // iteration. Without this guard we get a serial flood (~3 lines/sec)
+      // and the user has no way back to the selection menu without rebooting.
+      while (true) {
+        boardDriver.readSensors();
+        if (!boardDriver.getSensorState(4, 3)) break;
+        delay(100);
+      }
+      delay(500); // small debounce after lift
       currentMode = MODE_SELECTION;
       modeInitialized = false;
       showGameSelection();

--- a/board_driver.cpp
+++ b/board_driver.cpp
@@ -47,6 +47,8 @@ void BoardDriver::begin() {
         for (int col = 0; col < 8; col++) {
             sensorState[row][col] = false;
             sensorPrev[row][col] = false;
+            sensorRawLast[row][col] = false;
+            sensorStableCount[row][col] = 0;
         }
     }
 }
@@ -72,7 +74,20 @@ void BoardDriver::readSensors() {
         delayMicroseconds(100);
         for (int col = 0; col < NUM_COLS; col++) {
             int sensorVal = digitalRead(colPins[col]);
-            sensorState[row][col] = (sensorVal == LOW);
+            bool raw = (sensorVal == LOW);
+
+            // Debounce: only flip the public state after N consecutive
+            // identical raw reads. Prevents spurious detections when
+            // pieces slide across squares or noise hits the hall sensor.
+            if (raw == sensorRawLast[row][col]) {
+                if (sensorStableCount[row][col] < 255) sensorStableCount[row][col]++;
+            } else {
+                sensorRawLast[row][col] = raw;
+                sensorStableCount[row][col] = 1;
+            }
+            if (sensorStableCount[row][col] >= SENSOR_DEBOUNCE_SCANS) {
+                sensorState[row][col] = raw;
+            }
         }
     }
     loadShiftRegister(0x00);

--- a/board_driver.h
+++ b/board_driver.h
@@ -12,6 +12,12 @@
 #define LED_COUNT   (NUM_ROWS * NUM_COLS)
 #define BRIGHTNESS  100
 
+// Debounce: a sensor reading must be the same for this many consecutive
+// scans before the public state flips. Each readSensors() call adds 1
+// scan, so with the ~50ms loop delay this is roughly N*50ms of stability.
+// Tune up if pieces give false-positive flickers when sliding.
+#define SENSOR_DEBOUNCE_SCANS 3
+
 // Shift Register (74HC594) Pins
 #define SER_PIN     2   // Serial data input (74HC594 pin 14)
 #define SRCLK_PIN   3   // Shift register clock (pin 11)
@@ -30,7 +36,12 @@ private:
     byte rowPatterns[8];
     bool sensorState[8][8];
     bool sensorPrev[8][8];
-    
+
+    // Debounce buffers: latest raw read, count of consecutive identical
+    // raw reads since the public state last changed.
+    bool sensorRawLast[8][8];
+    uint8_t sensorStableCount[8][8];
+
     void loadShiftRegister(byte data);
     int getPixelIndex(int row, int col);
 

--- a/chess_bot.cpp
+++ b/chess_bot.cpp
@@ -144,7 +144,7 @@ void ChessBot::update() {
                             // Show possible moves
                             int moveCount = 0;
                             int moves[MAX_MOVES_PER_PIECE][2];
-                            _chessEngine->getPossibleMoves(board, row, col, moveCount, moves);
+                            _chessEngine->getLegalMoves(board, &state, row, col, moveCount, moves);
                             
                             for (int i = 0; i < moveCount; i++) {
                                 _boardDriver->setSquareLED(moves[i][0], moves[i][1], 255, 255, 255); // White
@@ -234,7 +234,7 @@ void ChessBot::update() {
                             // Show possible moves again
                             int moveCount = 0;
                             int moves[MAX_MOVES_PER_PIECE][2];
-                            _chessEngine->getPossibleMoves(board, selectedRow, selectedCol, moveCount, moves);
+                            _chessEngine->getLegalMoves(board, &state, selectedRow, selectedCol, moveCount, moves);
                             
                             for (int i = 0; i < moveCount; i++) {
                                 _boardDriver->setSquareLED(moves[i][0], moves[i][1], 255, 255, 255); // White
@@ -436,7 +436,7 @@ void ChessBot::makeBotMove() {
                     botThinking = false;
                     return;
                 }
-                if (!_chessEngine->isValidMove(board, fromRow, fromCol, toRow, toCol)) {
+                if (!_chessEngine->isLegalMove(board, &state, fromRow, fromCol, toRow, toCol)) {
                     Serial.print("Bot move ");
                     Serial.print(bestMove);
                     Serial.println(" rejected by local engine - aborting, returning to player");
@@ -563,11 +563,12 @@ bool ChessBot::parseMove(String move, int &fromRow, int &fromCol, int &toRow, in
 void ChessBot::executeBotMove(int fromRow, int fromCol, int toRow, int toCol) {
     char piece = board[fromRow][fromCol];
     char capturedPiece = board[toRow][toCol];
-    
-    // Update board state
-    board[toRow][toCol] = piece;
-    board[fromRow][fromCol] = ' ';
-    
+
+    // Apply via engine: handles castling rook, en-passant capture, state updates.
+    // Bot always promotes to queen (the Stockfish API string includes a 5th
+    // char like 'e7e8q' for promotion; we don't parse it yet so default to Q).
+    _chessEngine->applyMove(board, &state, fromRow, fromCol, toRow, toCol);
+
     Serial.print("Bot wants to move piece from ");
     Serial.print((char)('a' + fromCol));
     Serial.print(8 - fromRow);
@@ -575,22 +576,50 @@ void ChessBot::executeBotMove(int fromRow, int fromCol, int toRow, int toCol) {
     Serial.print((char)('a' + toCol));
     Serial.println(8 - toRow);
     Serial.println("Please make this move on the physical board...");
-    
-    // Show the move that needs to be made
+
     showBotMoveIndicator(fromRow, fromCol, toRow, toCol);
-    
-    // Wait for user to physically complete the bot's move
     waitForBotMoveCompletion(fromRow, fromCol, toRow, toCol);
-    
+
     if (capturedPiece != ' ') {
         Serial.print("Piece captured: ");
         Serial.println(capturedPiece);
         _boardDriver->captureAnimation();
     }
-    
-    // Flash confirmation on the destination square
+
     confirmSquareCompletion(toRow, toCol);
-    
+
+    // Game over after bot move?
+    GameResult r = _chessEngine->getGameResult(board, &state, 'w');
+    if (r != GAME_ONGOING) {
+        Serial.print("Game over after bot move: result=");
+        Serial.println(r);
+        if (r == GAME_CHECKMATE_BLACK_WINS) {
+            // Bot won. Pulse red.
+            for (int p = 0; p < 3; p++) {
+                for (int rr = 0; rr < 8; rr++)
+                    for (int cc = 0; cc < 8; cc++)
+                        _boardDriver->setSquareLED(rr, cc, 255, 0, 0, 0);
+                _boardDriver->showLEDs(); delay(300);
+                _boardDriver->clearAllLEDs(); delay(300);
+            }
+        } else if (r == GAME_STALEMATE || r == GAME_DRAW_50_MOVE || r == GAME_DRAW_INSUFFICIENT_MATERIAL) {
+            _boardDriver->fireworkAnimation();
+        }
+    } else if (_chessEngine->isInCheck(board, 'w')) {
+        Serial.println("You are in CHECK!");
+        // Blink white king
+        for (int rr = 0; rr < 8; rr++)
+            for (int cc = 0; cc < 8; cc++)
+                if (board[rr][cc] == 'K') {
+                    for (int b = 0; b < 3; b++) {
+                        _boardDriver->setSquareLED(rr, cc, 255, 0, 0, 0);
+                        _boardDriver->showLEDs(); delay(150);
+                        _boardDriver->setSquareLED(rr, cc, 0, 0, 0, 0);
+                        _boardDriver->showLEDs(); delay(150);
+                    }
+                }
+    }
+
     Serial.println("Bot move completed. Your turn!");
 }
 
@@ -626,6 +655,8 @@ void ChessBot::showConnectionStatus() {
 }
 
 void ChessBot::initializeBoard() {
+    // Reset game state (castling rights, en-passant, halfmove clock)
+    state.reset();
     // Copy initial board state
     for (int row = 0; row < 8; row++) {
         for (int col = 0; col < 8; col++) {
@@ -654,11 +685,11 @@ void ChessBot::waitForBoardSetup() {
 
 void ChessBot::processPlayerMove(int fromRow, int fromCol, int toRow, int toCol, char piece) {
     char capturedPiece = board[toRow][toCol];
-    
-    // Update board state
-    board[toRow][toCol] = piece;
-    board[fromRow][fromCol] = ' ';
-    
+
+    // Apply via engine: handles castling rook, en-passant capture, state updates,
+    // and auto-promotes to queen (player can't currently choose in bot mode).
+    _chessEngine->applyMove(board, &state, fromRow, fromCol, toRow, toCol);
+
     Serial.print("Player moved ");
     Serial.print(piece);
     Serial.print(" from ");
@@ -667,19 +698,16 @@ void ChessBot::processPlayerMove(int fromRow, int fromCol, int toRow, int toCol,
     Serial.print(" to ");
     Serial.print((char)('a' + toCol));
     Serial.println(8 - toRow);
-    
+
     if (capturedPiece != ' ') {
         Serial.print("Captured ");
         Serial.println(capturedPiece);
         _boardDriver->captureAnimation();
     }
-    
-    // Check for pawn promotion
+
     if (_chessEngine->isPawnPromotion(piece, toRow)) {
-        char promotedPiece = _chessEngine->getPromotedPiece(piece);
-        board[toRow][toCol] = promotedPiece;
-        Serial.print("Pawn promoted to ");
-        Serial.println(promotedPiece);
+        Serial.print("Pawn auto-promoted to ");
+        Serial.println(board[toRow][toCol]);
         _boardDriver->promotionAnimation(toCol);
     }
 }

--- a/chess_bot.cpp
+++ b/chess_bot.cpp
@@ -143,7 +143,7 @@ void ChessBot::update() {
                             
                             // Show possible moves
                             int moveCount = 0;
-                            int moves[27][2];
+                            int moves[MAX_MOVES_PER_PIECE][2];
                             _chessEngine->getPossibleMoves(board, row, col, moveCount, moves);
                             
                             for (int i = 0; i < moveCount; i++) {
@@ -233,7 +233,7 @@ void ChessBot::update() {
                             
                             // Show possible moves again
                             int moveCount = 0;
-                            int moves[27][2];
+                            int moves[MAX_MOVES_PER_PIECE][2];
                             _chessEngine->getPossibleMoves(board, selectedRow, selectedCol, moveCount, moves);
                             
                             for (int i = 0; i < moveCount; i++) {
@@ -335,14 +335,27 @@ String ChessBot::makeStockfishRequest(String fen) {
 }
 
 bool ChessBot::parseStockfishResponse(String response, String &bestMove) {
-    // Find JSON content
-    int jsonStart = response.indexOf("{");
+    // Split HTTP headers from body. The body starts after the first blank line ("\r\n\r\n").
+    // Otherwise indexOf("{") catches the first JSON-shaped header (e.g. Cloudflare's `Nel:`),
+    // which makes the parser fragile every time the upstream provider tweaks its headers.
+    int bodyStart = response.indexOf("\r\n\r\n");
+    if (bodyStart != -1) {
+        bodyStart += 4;
+    } else {
+        // Fallback: some clients return only \n\n separators
+        bodyStart = response.indexOf("\n\n");
+        bodyStart = (bodyStart != -1) ? bodyStart + 2 : 0;
+    }
+    String body = response.substring(bodyStart);
+
+    // Find JSON content inside the body
+    int jsonStart = body.indexOf("{");
     if (jsonStart == -1) {
-        Serial.println("No JSON found in response");
+        Serial.println("No JSON found in response body");
         return false;
     }
     
-    String json = response.substring(jsonStart);
+    String json = body.substring(jsonStart);
     Serial.print("Extracted JSON: ");
     Serial.println(json);
     
@@ -408,7 +421,30 @@ void ChessBot::makeBotMove() {
             if (parseMove(bestMove, fromRow, fromCol, toRow, toCol)) {
                 Serial.print("Bot move: ");
                 Serial.println(bestMove);
-                
+
+                // Sanity-check the API response against the local engine before
+                // mutating the board. Protects against malformed JSON, partially-
+                // received responses, retried requests producing stale moves, or
+                // (rare) the upstream API returning a move for the wrong side.
+                char piece = board[fromRow][fromCol];
+                if (piece == ' ') {
+                    Serial.print("Bot move references empty square ");
+                    Serial.print((char)('a' + fromCol));
+                    Serial.print(8 - fromRow);
+                    Serial.println(" - aborting move, returning to player");
+                    isWhiteTurn = true;
+                    botThinking = false;
+                    return;
+                }
+                if (!_chessEngine->isValidMove(board, fromRow, fromCol, toRow, toCol)) {
+                    Serial.print("Bot move ");
+                    Serial.print(bestMove);
+                    Serial.println(" rejected by local engine - aborting, returning to player");
+                    isWhiteTurn = true;
+                    botThinking = false;
+                    return;
+                }
+
                 executeBotMove(fromRow, fromCol, toRow, toCol);
                 
                 // Switch back to player's turn
@@ -419,14 +455,17 @@ void ChessBot::makeBotMove() {
             } else {
                 Serial.println("Failed to parse bot move");
                 botThinking = false;
+                isWhiteTurn = true;
             }
         } else {
             Serial.println("Failed to parse Stockfish response");
             botThinking = false;
+            isWhiteTurn = true;
         }
     } else {
         Serial.println("No response from Stockfish API");
         botThinking = false;
+        isWhiteTurn = true;
     }
 }
 

--- a/chess_bot.h
+++ b/chess_bot.h
@@ -24,6 +24,8 @@ private:
         {'p','p','p','p','p','p','p','p'},  // row 6 (rank 7)
         {'r','n','b','q','k','b','n','r'}   // row 7 (rank 8)
     };
+
+    GameState state; // castling rights, en-passant, halfmove clock
     
     StockfishSettings settings;
     BotDifficulty difficulty;

--- a/chess_engine.cpp
+++ b/chess_engine.cpp
@@ -207,7 +207,7 @@ char ChessEngine::getPieceColor(char piece) {
 // Move validation
 bool ChessEngine::isValidMove(const char board[8][8], int fromRow, int fromCol, int toRow, int toCol) {
     int moveCount = 0;
-    int moves[28][2]; // Maximum possible moves for a queen
+    int moves[MAX_MOVES_PER_PIECE][2]; // sized via chess_engine.h constant
     
     getPossibleMoves(board, fromRow, fromCol, moveCount, moves);
     

--- a/chess_engine.cpp
+++ b/chess_engine.cpp
@@ -249,3 +249,596 @@ char ChessEngine::algebraicToCol(char file) {
 int ChessEngine::algebraicToRow(int rank) {
     return rank - 1;
 }
+
+// =============================================================
+// Phase 2: legal-move filtering, check/checkmate, castling,
+// en passant, draws, and self-tests.
+// =============================================================
+
+bool ChessEngine::findKing(const char board[8][8], char color, int &kingRow, int &kingCol) {
+    char target = (color == 'w') ? 'K' : 'k';
+    for (int r = 0; r < 8; r++) {
+        for (int c = 0; c < 8; c++) {
+            if (board[r][c] == target) {
+                kingRow = r;
+                kingCol = c;
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool ChessEngine::isSquareAttacked(const char board[8][8], int row, int col, char byColor) {
+    // Iterate every opponent piece and check if it pseudo-attacks (row,col).
+    // For pawns we hand-roll the diagonal capture pattern instead of going
+    // through addPawnMoves (which would also include the forward push and
+    // a 2-square push that aren't attacks).
+    for (int r = 0; r < 8; r++) {
+        for (int c = 0; c < 8; c++) {
+            char piece = board[r][c];
+            if (piece == ' ') continue;
+            if (getPieceColor(piece) != byColor) continue;
+
+            char up = (piece >= 'a' && piece <= 'z') ? piece - 32 : piece;
+
+            if (up == 'P') {
+                int dir = (byColor == 'w') ? 1 : -1;
+                if (r + dir == row && (c - 1 == col || c + 1 == col)) return true;
+                continue;
+            }
+
+            // For non-pawn pieces, generate pseudo-legal moves and check
+            // if any lands on (row,col). We use the existing helpers here;
+            // they return both quiet moves and captures, which is fine
+            // because we just want to know whether the square is reachable.
+            int moveCount = 0;
+            int moves[MAX_MOVES_PER_PIECE][2];
+            switch (up) {
+                case 'R': addRookMoves(board, r, c, byColor, moveCount, moves); break;
+                case 'N': addKnightMoves(board, r, c, byColor, moveCount, moves); break;
+                case 'B': addBishopMoves(board, r, c, byColor, moveCount, moves); break;
+                case 'Q': addQueenMoves(board, r, c, byColor, moveCount, moves); break;
+                case 'K': {
+                    // For the king, only adjacent squares attack — we cannot
+                    // call addKingMoves recursively from inside isInCheck via
+                    // addCastlingMoves, but plain king moves are safe.
+                    int kingDeltas[8][2] = {{1,0},{-1,0},{0,1},{0,-1},{1,1},{1,-1},{-1,1},{-1,-1}};
+                    for (int i = 0; i < 8; i++) {
+                        if (r + kingDeltas[i][0] == row && c + kingDeltas[i][1] == col) return true;
+                    }
+                    continue;
+                }
+                default: continue;
+            }
+            for (int i = 0; i < moveCount; i++) {
+                if (moves[i][0] == row && moves[i][1] == col) return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool ChessEngine::isInCheck(const char board[8][8], char color) {
+    int kr, kc;
+    if (!findKing(board, color, kr, kc)) return false;
+    char attacker = (color == 'w') ? 'b' : 'w';
+    return isSquareAttacked(board, kr, kc, attacker);
+}
+
+void ChessEngine::addPawnMovesEP(const char board[8][8], const GameState* state, int row, int col, char pieceColor, int &moveCount, int moves[][2]) {
+    if (!state || state->enPassantRow < 0) return;
+    int dir = (pieceColor == 'w') ? 1 : -1;
+    // EP target is the square *behind* the just-advanced enemy pawn,
+    // so a capturing pawn must move row+dir == enPassantRow and
+    // col +/- 1 == enPassantCol.
+    if (row + dir == state->enPassantRow && (col - 1 == state->enPassantCol || col + 1 == state->enPassantCol)) {
+        moves[moveCount][0] = state->enPassantRow;
+        moves[moveCount][1] = state->enPassantCol;
+        moveCount++;
+    }
+}
+
+void ChessEngine::addCastlingMoves(const char board[8][8], const GameState* state, int row, int col, char pieceColor, int &moveCount, int moves[][2]) {
+    if (!state) return;
+
+    // The king must be on its home square and not in check.
+    if (pieceColor == 'w' && (row != 0 || col != 4)) return;
+    if (pieceColor == 'b' && (row != 7 || col != 4)) return;
+    char enemy = (pieceColor == 'w') ? 'b' : 'w';
+    if (isSquareAttacked(board, row, col, enemy)) return;
+
+    bool canKingside  = (pieceColor == 'w') ? state->whiteCanCastleKingside  : state->blackCanCastleKingside;
+    bool canQueenside = (pieceColor == 'w') ? state->whiteCanCastleQueenside : state->blackCanCastleQueenside;
+    char rookChar = (pieceColor == 'w') ? 'R' : 'r';
+
+    if (canKingside) {
+        // Squares between king (col 4) and kingside rook (col 7) must be empty,
+        // and the king's path (cols 4,5,6) must not be attacked.
+        if (board[row][5] == ' ' && board[row][6] == ' ' && board[row][7] == rookChar
+            && !isSquareAttacked(board, row, 5, enemy)
+            && !isSquareAttacked(board, row, 6, enemy)) {
+            moves[moveCount][0] = row;
+            moves[moveCount][1] = 6;
+            moveCount++;
+        }
+    }
+    if (canQueenside) {
+        // Squares b/c/d (cols 1,2,3) must be empty between king (col 4) and rook (col 0).
+        // King's path (cols 4,3,2) must not be attacked. b-file (col 1) needs empty
+        // but not unattacked (rook can pass through attack).
+        if (board[row][1] == ' ' && board[row][2] == ' ' && board[row][3] == ' ' && board[row][0] == rookChar
+            && !isSquareAttacked(board, row, 3, enemy)
+            && !isSquareAttacked(board, row, 2, enemy)) {
+            moves[moveCount][0] = row;
+            moves[moveCount][1] = 2;
+            moveCount++;
+        }
+    }
+}
+
+bool ChessEngine::isCastlingMove(const char board[8][8], int fromRow, int fromCol, int toRow, int toCol) {
+    char piece = board[fromRow][fromCol];
+    if (piece != 'K' && piece != 'k') return false;
+    if (fromRow != toRow) return false;
+    int delta = toCol - fromCol;
+    return (delta == 2 || delta == -2);
+}
+
+bool ChessEngine::isEnPassantMove(const char board[8][8], const GameState* state, int fromRow, int fromCol, int toRow, int toCol) {
+    if (!state || state->enPassantRow < 0) return false;
+    char piece = board[fromRow][fromCol];
+    if (piece != 'P' && piece != 'p') return false;
+    if (toRow != state->enPassantRow || toCol != state->enPassantCol) return false;
+    // Diagonal pawn move to an empty square => EP.
+    return (board[toRow][toCol] == ' ' && fromCol != toCol);
+}
+
+void ChessEngine::getLegalMoves(const char board[8][8], const GameState* state, int row, int col, int &moveCount, int moves[][2]) {
+    // 1) start with pseudo-legal moves
+    int pseudoCount = 0;
+    int pseudo[MAX_MOVES_PER_PIECE][2];
+    getPossibleMoves(board, row, col, pseudoCount, pseudo);
+
+    char piece = board[row][col];
+    if (piece == ' ') { moveCount = 0; return; }
+    char pieceColor = getPieceColor(piece);
+
+    // 2) augment with castling + en-passant when state available
+    if (state) {
+        char up = (piece >= 'a' && piece <= 'z') ? piece - 32 : piece;
+        if (up == 'K') addCastlingMoves(board, state, row, col, pieceColor, pseudoCount, pseudo);
+        if (up == 'P') addPawnMovesEP(board, state, row, col, pieceColor, pseudoCount, pseudo);
+    }
+
+    // 3) filter out moves that would leave own king in check
+    moveCount = 0;
+    for (int i = 0; i < pseudoCount; i++) {
+        int tr = pseudo[i][0];
+        int tc = pseudo[i][1];
+
+        // Simulate the move on a scratch board
+        char scratch[8][8];
+        for (int r = 0; r < 8; r++)
+            for (int c = 0; c < 8; c++) scratch[r][c] = board[r][c];
+
+        char captured = scratch[tr][tc];
+        scratch[tr][tc] = piece;
+        scratch[row][col] = ' ';
+
+        // Castling: also move the rook on the scratch board so the
+        // king-attacked check after the move is realistic (a rook
+        // pinned through the king matters).
+        if (state) {
+            char up = (piece >= 'a' && piece <= 'z') ? piece - 32 : piece;
+            if (up == 'K' && (tc - col == 2 || tc - col == -2)) {
+                if (tc == 6) { // kingside
+                    scratch[tr][5] = scratch[tr][7];
+                    scratch[tr][7] = ' ';
+                } else if (tc == 2) { // queenside
+                    scratch[tr][3] = scratch[tr][0];
+                    scratch[tr][0] = ' ';
+                }
+            }
+            // En passant: remove the captured pawn from its actual square
+            if (up == 'P' && tc != col && captured == ' ' && state->enPassantRow == tr && state->enPassantCol == tc) {
+                int capturedPawnRow = (pieceColor == 'w') ? tr - 1 : tr + 1;
+                scratch[capturedPawnRow][tc] = ' ';
+            }
+        }
+
+        if (!isInCheck(scratch, pieceColor)) {
+            moves[moveCount][0] = tr;
+            moves[moveCount][1] = tc;
+            moveCount++;
+        }
+    }
+}
+
+bool ChessEngine::isLegalMove(const char board[8][8], const GameState* state, int fromRow, int fromCol, int toRow, int toCol) {
+    int moveCount = 0;
+    int moves[MAX_MOVES_PER_PIECE][2];
+    getLegalMoves(board, state, fromRow, fromCol, moveCount, moves);
+    for (int i = 0; i < moveCount; i++) {
+        if (moves[i][0] == toRow && moves[i][1] == toCol) return true;
+    }
+    return false;
+}
+
+bool ChessEngine::hasAnyLegalMove(const char board[8][8], const GameState* state, char color) {
+    for (int r = 0; r < 8; r++) {
+        for (int c = 0; c < 8; c++) {
+            char piece = board[r][c];
+            if (piece == ' ') continue;
+            if (getPieceColor(piece) != color) continue;
+            int moveCount = 0;
+            int moves[MAX_MOVES_PER_PIECE][2];
+            getLegalMoves(board, state, r, c, moveCount, moves);
+            if (moveCount > 0) return true;
+        }
+    }
+    return false;
+}
+
+GameResult ChessEngine::getGameResult(const char board[8][8], const GameState* state, char colorToMove) {
+    // Insufficient material: K vs K, K+B vs K, K+N vs K, K+B vs K+B (same color squares not checked here)
+    int wPieces = 0, bPieces = 0;
+    int wMinor = 0, bMinor = 0;
+    bool heavyOrPawn = false;
+    for (int r = 0; r < 8; r++) {
+        for (int c = 0; c < 8; c++) {
+            char p = board[r][c];
+            if (p == ' ') continue;
+            char up = (p >= 'a' && p <= 'z') ? p - 32 : p;
+            bool isWhite = (p == up);
+            if (up == 'P' || up == 'R' || up == 'Q') heavyOrPawn = true;
+            if (isWhite) {
+                wPieces++;
+                if (up == 'B' || up == 'N') wMinor++;
+            } else {
+                bPieces++;
+                if (up == 'B' || up == 'N') bMinor++;
+            }
+        }
+    }
+    if (!heavyOrPawn) {
+        // K vs K, or K + 1 minor vs K
+        if (wPieces == 1 && bPieces == 1) return GAME_DRAW_INSUFFICIENT_MATERIAL;
+        if ((wPieces == 1 && bPieces == 2 && bMinor == 1) ||
+            (bPieces == 1 && wPieces == 2 && wMinor == 1)) {
+            return GAME_DRAW_INSUFFICIENT_MATERIAL;
+        }
+    }
+
+    // 50-move rule
+    if (state && state->halfMoveClock >= 100) return GAME_DRAW_50_MOVE;
+
+    // Checkmate / Stalemate
+    if (!hasAnyLegalMove(board, state, colorToMove)) {
+        if (isInCheck(board, colorToMove)) {
+            return (colorToMove == 'w') ? GAME_CHECKMATE_BLACK_WINS : GAME_CHECKMATE_WHITE_WINS;
+        }
+        return GAME_STALEMATE;
+    }
+
+    return GAME_ONGOING;
+}
+
+void ChessEngine::applyMove(char board[8][8], GameState* state,
+                            int fromRow, int fromCol, int toRow, int toCol,
+                            char promoteTo) {
+    char piece = board[fromRow][fromCol];
+    char captured = board[toRow][toCol];
+    char up = (piece >= 'a' && piece <= 'z') ? piece - 32 : piece;
+    char color = getPieceColor(piece);
+
+    bool isPawnMove = (up == 'P');
+    bool isCapture = (captured != ' ');
+    bool isCastle = (up == 'K' && (toCol - fromCol == 2 || toCol - fromCol == -2));
+    bool isEP = false;
+
+    if (state && isPawnMove && fromCol != toCol && captured == ' ' &&
+        toRow == state->enPassantRow && toCol == state->enPassantCol) {
+        // En-passant capture
+        isEP = true;
+        isCapture = true;
+        int capturedPawnRow = (color == 'w') ? toRow - 1 : toRow + 1;
+        board[capturedPawnRow][toCol] = ' ';
+    }
+
+    // Move the piece
+    board[toRow][toCol] = piece;
+    board[fromRow][fromCol] = ' ';
+
+    // Promotion
+    if (isPawnMove && (toRow == 7 || toRow == 0)) {
+        if (promoteTo != 0) {
+            // Caller specifies the case correctly (uppercase for white, lowercase for black).
+            board[toRow][toCol] = promoteTo;
+        } else {
+            board[toRow][toCol] = (color == 'w') ? 'Q' : 'q';
+        }
+    }
+
+    // Castling: also move the rook
+    if (isCastle) {
+        if (toCol == 6) {
+            board[toRow][5] = board[toRow][7];
+            board[toRow][7] = ' ';
+        } else if (toCol == 2) {
+            board[toRow][3] = board[toRow][0];
+            board[toRow][0] = ' ';
+        }
+    }
+
+    if (state) {
+        // Halfmove clock
+        if (isPawnMove || isCapture) state->halfMoveClock = 0;
+        else state->halfMoveClock++;
+
+        // Castling rights
+        if (up == 'K') {
+            if (color == 'w') { state->whiteCanCastleKingside = false; state->whiteCanCastleQueenside = false; }
+            else              { state->blackCanCastleKingside = false; state->blackCanCastleQueenside = false; }
+        }
+        if (up == 'R') {
+            if (color == 'w' && fromRow == 0) {
+                if (fromCol == 0) state->whiteCanCastleQueenside = false;
+                if (fromCol == 7) state->whiteCanCastleKingside = false;
+            }
+            if (color == 'b' && fromRow == 7) {
+                if (fromCol == 0) state->blackCanCastleQueenside = false;
+                if (fromCol == 7) state->blackCanCastleKingside = false;
+            }
+        }
+        // If a rook is captured on its starting square, that side loses castling
+        if (toRow == 0 && toCol == 0) state->whiteCanCastleQueenside = false;
+        if (toRow == 0 && toCol == 7) state->whiteCanCastleKingside  = false;
+        if (toRow == 7 && toCol == 0) state->blackCanCastleQueenside = false;
+        if (toRow == 7 && toCol == 7) state->blackCanCastleKingside  = false;
+
+        // En-passant target: set only on a 2-square pawn advance
+        if (up == 'P' && (toRow - fromRow == 2 || fromRow - toRow == 2)) {
+            state->enPassantRow = (fromRow + toRow) / 2;
+            state->enPassantCol = fromCol;
+        } else {
+            state->enPassantRow = -1;
+            state->enPassantCol = -1;
+        }
+
+        // Last-move tracking
+        state->lastFromRow = fromRow;
+        state->lastFromCol = fromCol;
+        state->lastToRow = toRow;
+        state->lastToCol = toCol;
+        state->lastPiece = piece;
+    }
+}
+
+// =============================================================
+// Self-tests. Run at boot from setup(); print summary to Serial.
+// All tests are pure C++ and return a fail count without touching
+// the board hardware or WiFi.
+// =============================================================
+
+static void copyBoard(char dst[8][8], const char src[8][8]) {
+    for (int r = 0; r < 8; r++)
+        for (int c = 0; c < 8; c++) dst[r][c] = src[r][c];
+}
+
+int ChessEngine::runSelfTests() {
+    int failures = 0;
+    Serial.println("=== ChessEngine self-tests ===");
+
+    // Initial position used as a base.
+    const char start[8][8] = {
+        {'R','N','B','Q','K','B','N','R'},
+        {'P','P','P','P','P','P','P','P'},
+        {' ',' ',' ',' ',' ',' ',' ',' '},
+        {' ',' ',' ',' ',' ',' ',' ',' '},
+        {' ',' ',' ',' ',' ',' ',' ',' '},
+        {' ',' ',' ',' ',' ',' ',' ',' '},
+        {'p','p','p','p','p','p','p','p'},
+        {'r','n','b','q','k','b','n','r'}
+    };
+
+    // Test 1: white pawn on e2 has 2 forward moves at start
+    {
+        int n; int m[MAX_MOVES_PER_PIECE][2];
+        getLegalMoves(start, nullptr, 1, 4, n, m);
+        if (n != 2) { failures++; Serial.print("FAIL T1 e2 pawn moves="); Serial.println(n); }
+        else Serial.println("PASS T1: e2 pawn has 2 legal moves");
+    }
+
+    // Test 2: white knight on b1 has 2 legal moves (a3, c3)
+    {
+        int n; int m[MAX_MOVES_PER_PIECE][2];
+        getLegalMoves(start, nullptr, 0, 1, n, m);
+        if (n != 2) { failures++; Serial.print("FAIL T2 b1 knight moves="); Serial.println(n); }
+        else Serial.println("PASS T2: b1 knight has 2 legal moves");
+    }
+
+    // Test 3: at start, white is not in check, has many legal moves, game ongoing
+    {
+        bool check = isInCheck(start, 'w');
+        if (check) { failures++; Serial.println("FAIL T3 white in check at start?!"); }
+        else Serial.println("PASS T3: no check at start");
+    }
+
+    // Test 4: Fool's Mate position. After 1.f3 e5 2.g4 Qh4# white is mated.
+    // White pawn pushed g2->g4 sits on (3,6); black queen now on h4 = (3,7);
+    // black pawn on e5 = (4,4); white pawn f2->f3 sits on (2,5).
+    {
+        char b[8][8] = {
+            {'R','N','B','Q','K','B','N','R'},
+            {'P','P','P','P','P',' ',' ','P'},
+            {' ',' ',' ',' ',' ','P',' ',' '},
+            {' ',' ',' ',' ',' ',' ','P','q'},
+            {' ',' ',' ',' ','p',' ',' ',' '},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {'p','p','p','p',' ','p','p','p'},
+            {'r','n','b',' ','k','b','n','r'}
+        };
+        bool check = isInCheck(b, 'w');
+        bool any = hasAnyLegalMove(b, nullptr, 'w');
+        if (!check) { failures++; Serial.println("FAIL T4 white not in check after Fool's Mate"); }
+        if (any)    { failures++; Serial.println("FAIL T4 white has legal move after Fool's Mate"); }
+        GameResult r = getGameResult(b, nullptr, 'w');
+        if (r != GAME_CHECKMATE_BLACK_WINS) { failures++; Serial.print("FAIL T4 result="); Serial.println(r); }
+        else Serial.println("PASS T4: Fool's Mate detected");
+    }
+
+    // Test 5: pinned piece may not move off the pin
+    // White king on e1, white rook on e2, black queen on e8. The rook
+    // on e2 is pinned and cannot move off the e-file.
+    {
+        char b[8][8] = {
+            {' ',' ',' ',' ','K',' ',' ',' '},
+            {' ',' ',' ',' ','R',' ',' ',' '},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {' ',' ',' ',' ','q',' ',' ',' '}
+        };
+        int n; int m[MAX_MOVES_PER_PIECE][2];
+        getLegalMoves(b, nullptr, 1, 4, n, m); // white rook on e2
+        // The rook can move along the e-file: to e3..e7 (5 squares) and capture the queen on e8 (1).
+        // It cannot leave the file (would expose king).
+        bool allOnFile = true;
+        for (int i = 0; i < n; i++) if (m[i][1] != 4) { allOnFile = false; break; }
+        if (!allOnFile) { failures++; Serial.println("FAIL T5 pinned rook left e-file"); }
+        else Serial.println("PASS T5: pinned rook stayed on file");
+    }
+
+    // Test 6: white kingside castling legal in the canonical position
+    {
+        char b[8][8] = {
+            {'R',' ',' ',' ','K',' ',' ','R'},
+            {'P','P','P','P','P','P','P','P'},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {'p','p','p','p','p','p','p','p'},
+            {'r','n','b','q','k','b','n','r'}
+        };
+        GameState st; // default: all castling allowed
+        int n; int m[MAX_MOVES_PER_PIECE][2];
+        getLegalMoves(b, &st, 0, 4, n, m); // white king on e1
+        bool foundKingside = false, foundQueenside = false;
+        for (int i = 0; i < n; i++) {
+            if (m[i][0] == 0 && m[i][1] == 6) foundKingside = true;
+            if (m[i][0] == 0 && m[i][1] == 2) foundQueenside = true;
+        }
+        if (!foundKingside)  { failures++; Serial.println("FAIL T6 kingside castle missing"); }
+        if (!foundQueenside) { failures++; Serial.println("FAIL T6 queenside castle missing"); }
+        if (foundKingside && foundQueenside) Serial.println("PASS T6: both castlings legal");
+    }
+
+    // Test 7: castling forbidden when king is in check
+    {
+        char b[8][8] = {
+            {'R',' ',' ',' ','K',' ',' ','R'},
+            {'P','P','P','P',' ','P','P','P'},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {' ',' ',' ',' ','q',' ',' ',' '},  // black queen attacks e1
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {'p','p','p','p',' ','p','p','p'},
+            {'r','n','b',' ','k','b','n','r'}
+        };
+        GameState st;
+        int n; int m[MAX_MOVES_PER_PIECE][2];
+        getLegalMoves(b, &st, 0, 4, n, m);
+        for (int i = 0; i < n; i++) {
+            if (m[i][1] == 6 || m[i][1] == 2) {
+                failures++;
+                Serial.print("FAIL T7 castle while in check at col="); Serial.println(m[i][1]);
+            }
+        }
+        Serial.println("PASS T7: no castling in check (or fail above)");
+    }
+
+    // Test 8: en passant capture available
+    {
+        // Position after 1.e4 ... 2.e5 d5  (white to move, can EP d6)
+        // Internally: white pawn just moved to (4,3) [d5 in our row=rank-1 mapping is wrong;
+        // remember row 0 = rank 1 so rank 5 = row 4, and d5 = (4,3)... wait.
+        // Actually internal: white pawn on row 3 = rank 4. We want a white pawn on
+        // row 4 (rank 5) col 4 (e5), and a black pawn just moved to row 4 col 3 (d5),
+        // so EP target is row 5 col 3 (d6).
+        char b[8][8] = {
+            {'R','N','B','Q','K','B','N','R'},
+            {'P','P','P','P',' ','P','P','P'},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {' ',' ',' ','p','P',' ',' ',' '},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {'p','p','p',' ','p','p','p','p'},
+            {'r','n','b','q','k','b','n','r'}
+        };
+        GameState st;
+        st.enPassantRow = 5;
+        st.enPassantCol = 3;
+        int n; int m[MAX_MOVES_PER_PIECE][2];
+        getLegalMoves(b, &st, 4, 4, n, m); // white pawn on e5 = (4,4)
+        bool foundEP = false;
+        for (int i = 0; i < n; i++) if (m[i][0] == 5 && m[i][1] == 3) foundEP = true;
+        if (!foundEP) { failures++; Serial.println("FAIL T8 en-passant move missing"); }
+        else Serial.println("PASS T8: en-passant offered");
+    }
+
+    // Test 9: insufficient material draw (K vs K)
+    {
+        char b[8][8] = {
+            {' ',' ',' ',' ','K',' ',' ',' '},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {' ',' ',' ',' ','k',' ',' ',' '}
+        };
+        GameResult r = getGameResult(b, nullptr, 'w');
+        if (r != GAME_DRAW_INSUFFICIENT_MATERIAL) { failures++; Serial.print("FAIL T9 result="); Serial.println(r); }
+        else Serial.println("PASS T9: K vs K is draw");
+    }
+
+    // Test 10: applyMove castling moves the rook too
+    {
+        char b[8][8] = {
+            {'R',' ',' ',' ','K',' ',' ','R'},
+            {'P','P','P','P','P','P','P','P'},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {' ',' ',' ',' ',' ',' ',' ',' '},
+            {'p','p','p','p','p','p','p','p'},
+            {'r','n','b','q','k','b','n','r'}
+        };
+        GameState st;
+        applyMove(b, &st, 0, 4, 0, 6); // white kingside castle
+        if (b[0][6] != 'K' || b[0][5] != 'R' || b[0][7] != ' ' || b[0][4] != ' ') {
+            failures++;
+            Serial.println("FAIL T10 castle layout wrong");
+        } else Serial.println("PASS T10: kingside castle layout correct");
+        if (st.whiteCanCastleKingside || st.whiteCanCastleQueenside) {
+            failures++;
+            Serial.println("FAIL T10 castle rights not cleared");
+        }
+    }
+
+    Serial.print("=== Self-tests complete: ");
+    Serial.print(10 - failures);
+    Serial.print("/10 passed");
+    if (failures > 0) {
+        Serial.print(", ");
+        Serial.print(failures);
+        Serial.print(" FAILURES ");
+    }
+    Serial.println(" ===");
+    return failures;
+}

--- a/chess_engine.h
+++ b/chess_engine.h
@@ -1,6 +1,13 @@
 #ifndef CHESS_ENGINE_H
 #define CHESS_ENGINE_H
 
+// Maximum number of moves a single piece can ever generate.
+// 27 = queen on an empty board (8 ranks + 8 files + 11 diagonals
+// minus the source square). Use 28 in arrays to leave a 1-slot guard
+// and keep all callers in sync (was inconsistent: chess_moves used 27,
+// chess_engine used 28).
+#define MAX_MOVES_PER_PIECE 28
+
 // ---------------------------
 // Chess Engine Class
 // ---------------------------

--- a/chess_engine.h
+++ b/chess_engine.h
@@ -1,6 +1,8 @@
 #ifndef CHESS_ENGINE_H
 #define CHESS_ENGINE_H
 
+#include <Arduino.h>
+
 // Maximum number of moves a single piece can ever generate.
 // 27 = queen on an empty board (8 ranks + 8 files + 11 diagonals
 // minus the source square). Use 28 in arrays to leave a 1-slot guard
@@ -8,41 +10,136 @@
 // chess_engine used 28).
 #define MAX_MOVES_PER_PIECE 28
 
+// Game outcome reported by getGameResult().
+enum GameResult {
+    GAME_ONGOING,
+    GAME_CHECKMATE_WHITE_WINS,
+    GAME_CHECKMATE_BLACK_WINS,
+    GAME_STALEMATE,
+    GAME_DRAW_50_MOVE,
+    GAME_DRAW_INSUFFICIENT_MATERIAL
+};
+
+// Per-game state needed for rules that can't be derived from the board
+// alone: castling rights, en-passant target, halfmove clock for the
+// 50-move rule, and the last move (used by en-passant detection and the
+// pretty-printer).
+//
+// The board representation in this firmware is:
+//   row 0 = rank 1 (white back rank)
+//   row 7 = rank 8 (black back rank)
+// White pieces are uppercase ('R','N','B','Q','K','P'),
+// black pieces are lowercase. ' ' means empty.
+struct GameState {
+    bool whiteCanCastleKingside;
+    bool whiteCanCastleQueenside;
+    bool blackCanCastleKingside;
+    bool blackCanCastleQueenside;
+
+    // En-passant target square. -1 / -1 if none.
+    // This is the square *the capturing pawn moves to*, i.e. the square
+    // behind the pawn that just made a 2-square advance.
+    int enPassantRow;
+    int enPassantCol;
+
+    // Halfmove clock for the 50-move rule (incremented every ply,
+    // reset on pawn move or capture). Triggers a draw at >= 100.
+    int halfMoveClock;
+
+    // Last move played, used by debug logs.
+    int lastFromRow;
+    int lastFromCol;
+    int lastToRow;
+    int lastToCol;
+    char lastPiece;
+
+    GameState() { reset(); }
+
+    void reset() {
+        whiteCanCastleKingside = true;
+        whiteCanCastleQueenside = true;
+        blackCanCastleKingside = true;
+        blackCanCastleQueenside = true;
+        enPassantRow = -1;
+        enPassantCol = -1;
+        halfMoveClock = 0;
+        lastFromRow = lastFromCol = -1;
+        lastToRow = lastToCol = -1;
+        lastPiece = ' ';
+    }
+};
+
 // ---------------------------
 // Chess Engine Class
 // ---------------------------
 class ChessEngine {
 private:
-    // Helper functions for move generation
+    // Helper functions for pseudo-legal move generation (do not filter
+    // moves that leave own king in check; use getLegalMoves for that).
     void addPawnMoves(const char board[8][8], int row, int col, char pieceColor, int &moveCount, int moves[][2]);
+    void addPawnMovesEP(const char board[8][8], const GameState* state, int row, int col, char pieceColor, int &moveCount, int moves[][2]);
     void addRookMoves(const char board[8][8], int row, int col, char pieceColor, int &moveCount, int moves[][2]);
     void addKnightMoves(const char board[8][8], int row, int col, char pieceColor, int &moveCount, int moves[][2]);
     void addBishopMoves(const char board[8][8], int row, int col, char pieceColor, int &moveCount, int moves[][2]);
     void addQueenMoves(const char board[8][8], int row, int col, char pieceColor, int &moveCount, int moves[][2]);
     void addKingMoves(const char board[8][8], int row, int col, char pieceColor, int &moveCount, int moves[][2]);
-    
+    void addCastlingMoves(const char board[8][8], const GameState* state, int row, int col, char pieceColor, int &moveCount, int moves[][2]);
+
     bool isSquareOccupiedByOpponent(const char board[8][8], int row, int col, char pieceColor);
     bool isSquareEmpty(const char board[8][8], int row, int col);
     bool isValidSquare(int row, int col);
-    char getPieceColor(char piece);
+
+    // Find the king of the given color. Returns false if not found.
+    bool findKing(const char board[8][8], char color, int &kingRow, int &kingCol);
 
 public:
     ChessEngine();
-    
-    // Main move generation function
+
+    // Pseudo-legal moves (does not filter own-check). Pass state=nullptr
+    // for tests / contexts where castling and en-passant aren't needed.
     void getPossibleMoves(const char board[8][8], int row, int col, int &moveCount, int moves[][2]);
-    
+
+    // Legal moves: pseudo-legal filtered by own-check, and including
+    // castling + en-passant when state is provided.
+    void getLegalMoves(const char board[8][8], const GameState* state, int row, int col, int &moveCount, int moves[][2]);
+
     // Move validation
     bool isValidMove(const char board[8][8], int fromRow, int fromCol, int toRow, int toCol);
-    
+    bool isLegalMove(const char board[8][8], const GameState* state, int fromRow, int fromCol, int toRow, int toCol);
+
+    // Attack / check detection
+    bool isSquareAttacked(const char board[8][8], int row, int col, char byColor);
+    bool isInCheck(const char board[8][8], char color);
+
+    // Outcome detection
+    bool hasAnyLegalMove(const char board[8][8], const GameState* state, char color);
+    GameResult getGameResult(const char board[8][8], const GameState* state, char colorToMove);
+
+    // Apply a move to the board AND update the state. Handles regular
+    // moves, captures, castling (moves the rook too), en-passant
+    // (removes the captured pawn from its actual square), and updates
+    // castling rights / en-passant target / halfmove clock. Promotion
+    // is NOT done here; pass the promoted piece via promoteTo (or 0 to
+    // skip).
+    void applyMove(char board[8][8], GameState* state,
+                   int fromRow, int fromCol, int toRow, int toCol,
+                   char promoteTo = 0);
+
     // Game state checks
     bool isPawnPromotion(char piece, int targetRow);
     char getPromotedPiece(char piece);
-    
-    // Utility functions
+    bool isCastlingMove(const char board[8][8], int fromRow, int fromCol, int toRow, int toCol);
+    bool isEnPassantMove(const char board[8][8], const GameState* state, int fromRow, int fromCol, int toRow, int toCol);
+
+    // Utility
+    char getPieceColor(char piece); // public so callers can ask
     void printMove(int fromRow, int fromCol, int toRow, int toCol);
     char algebraicToCol(char file);
     int algebraicToRow(int rank);
+
+    // Self-tests run at boot. Returns number of failures (0 = all pass).
+    // Prints results to Serial.
+    int runSelfTests();
 };
 
 #endif // CHESS_ENGINE_H

--- a/chess_moves.cpp
+++ b/chess_moves.cpp
@@ -3,318 +3,361 @@
 
 // Expected initial configuration (as printed in the grid)
 const char ChessMoves::INITIAL_BOARD[8][8] = {
-  {'R', 'N', 'B', 'Q', 'K', 'B', 'N', 'R'},  // row 0 (rank 1)
+  {'R', 'N', 'B', 'Q', 'K', 'B', 'N', 'R'},  // row 0 (rank 1) - white back rank
   {'P', 'P', 'P', 'P', 'P', 'P', 'P', 'P'},  // row 1 (rank 2)
-  {' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '},    // row 2 (rank 3)
-  {' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '},    // row 3 (rank 4)
-  {' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '},    // row 4 (rank 5)
-  {' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '},    // row 5 (rank 6)
-  {'p', 'p', 'p', 'p', 'p', 'p', 'p', 'p'},    // row 6 (rank 7)
-  {'r', 'n', 'b', 'q', 'k', 'b', 'n', 'r'}     // row 7 (rank 8)
+  {' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '},
+  {' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '},
+  {' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '},
+  {' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '},
+  {'p', 'p', 'p', 'p', 'p', 'p', 'p', 'p'},  // row 6 (rank 7)
+  {'r', 'n', 'b', 'q', 'k', 'b', 'n', 'r'}   // row 7 (rank 8) - black back rank
 };
 
 ChessMoves::ChessMoves(BoardDriver* bd, ChessEngine* ce) : boardDriver(bd), chessEngine(ce) {
-    // Initialize board state
     initializeBoard();
+    state.reset();
+    turnColor = 'w';
+    gameOver = false;
 }
 
 void ChessMoves::begin() {
-    Serial.println("Starting Chess Game Mode...");
-    
-    // Copy expected configuration into our board state
-    initializeBoard();
+    Serial.println("Starting Chess Game Mode (Human vs Human)...");
 
-    // Wait for board setup
+    initializeBoard();
+    state.reset();
+    turnColor = 'w';
+    gameOver = false;
+
     waitForBoardSetup();
-    
+
     Serial.println("Chess game ready to start!");
     boardDriver->fireworkAnimation();
 
-    // Initialize sensor previous state for move detection
     boardDriver->readSensors();
     boardDriver->updateSensorPrev();
 }
 
 void ChessMoves::update() {
+    if (gameOver) {
+        delay(500);
+        return;
+    }
+
     boardDriver->readSensors();
 
-    // Look for a piece pickup
+    // Look for a piece pickup (sensor went from active to inactive)
     for (int row = 0; row < 8; row++) {
         for (int col = 0; col < 8; col++) {
-            if (boardDriver->getSensorPrev(row, col) && !boardDriver->getSensorState(row, col)) {
-                char piece = board[row][col];
-                
-                // Skip empty squares
-                if (piece == ' ') continue;
-                
-                Serial.print("Piece lifted from ");
-                Serial.print((char)('a' + col));
-                Serial.println(row + 1);
-                
-                // Generate possible moves
-                int moveCount = 0;
-                int moves[MAX_MOVES_PER_PIECE][2]; // sized via chess_engine.h constant
-                chessEngine->getPossibleMoves(board, row, col, moveCount, moves);
-                
-                // Light up current square and possible move squares
-                boardDriver->setSquareLED(row, col, 0, 0, 0, 100); // Dimmer, but solid
-                
-                // Highlight possible move squares (including captures)
-                for (int i = 0; i < moveCount; i++) {
-                    int r = moves[i][0];
-                    int c = moves[i][1];
-                    
-                    // Different highlighting for empty squares vs capture squares
-                    if (board[r][c] == ' ') {
-                        boardDriver->setSquareLED(r, c, 0, 0, 0, 50); // Soft white for moves
+            if (!(boardDriver->getSensorPrev(row, col) && !boardDriver->getSensorState(row, col))) continue;
+
+            char piece = board[row][col];
+            if (piece == ' ') continue;
+
+            // Enforce turn order
+            if (chessEngine->getPieceColor(piece) != turnColor) {
+                Serial.print("Wrong turn: it's ");
+                Serial.print(turnColor == 'w' ? "white" : "black");
+                Serial.print(" to move, but lifted ");
+                Serial.println(piece);
+                // Brief red blink to signal wrong color, but don't block - user will replace
+                boardDriver->blinkSquare(row, col, 1);
+                boardDriver->updateSensorPrev();
+                return;
+            }
+
+            Serial.print("Piece lifted from ");
+            Serial.print((char)('a' + col));
+            Serial.println(row + 1);
+
+            // Generate LEGAL moves (filters self-check, includes castling/en-passant)
+            int moveCount = 0;
+            int moves[MAX_MOVES_PER_PIECE][2];
+            chessEngine->getLegalMoves(board, &state, row, col, moveCount, moves);
+
+            if (moveCount == 0) {
+                Serial.println("No legal moves for this piece (pinned or no escape)");
+                boardDriver->blinkSquare(row, col, 2);
+                boardDriver->updateSensorPrev();
+                return;
+            }
+
+            // Light up source + possible move squares
+            boardDriver->setSquareLED(row, col, 0, 0, 0, 100); // Soft white source
+            for (int i = 0; i < moveCount; i++) {
+                int r = moves[i][0];
+                int c = moves[i][1];
+                if (board[r][c] == ' ') {
+                    // En-passant target square shows pink (capture but empty)
+                    if (state.enPassantRow == r && state.enPassantCol == c &&
+                        (piece == 'P' || piece == 'p')) {
+                        boardDriver->setSquareLED(r, c, 200, 0, 100, 0);
                     } else {
-                        boardDriver->setSquareLED(r, c, 255, 0, 0, 50); // Red tint for captures
-                    }
-                }
-                boardDriver->showLEDs();
-                
-                // Wait for piece placement - handle both normal moves and captures
-                int targetRow = -1, targetCol = -1;
-                bool piecePlaced = false;
-                bool captureInProgress = false;
-
-                // Wait for a piece placement on any square
-                while (!piecePlaced) {
-                    boardDriver->readSensors();
-                    
-                    // First check if the original piece was placed back
-                    if (boardDriver->getSensorState(row, col)) {
-                        targetRow = row;
-                        targetCol = col;
-                        piecePlaced = true;
-                        break;
-                    }
-                    
-                    // Then check all squares for a regular move or capture initiation
-                    for (int r2 = 0; r2 < 8; r2++) {
-                        for (int c2 = 0; c2 < 8; c2++) {
-                            // Skip the original square which was already checked
-                            if (r2 == row && c2 == col) continue;
-                            
-                            // Check if this would be a legal move
-                            bool isLegalMove = false;
-                            for (int i = 0; i < moveCount; i++) {
-                                if (moves[i][0] == r2 && moves[i][1] == c2) {
-                                    isLegalMove = true;
-                                    break;
-                                }
-                            }
-                            
-                            // If not a legal move, no need to check further
-                            if (!isLegalMove) continue;
-                            
-                            // For capture moves: detect when the target piece is removed
-                            if (board[r2][c2] != ' ' && !boardDriver->getSensorState(r2, c2) && boardDriver->getSensorPrev(r2, c2)) {
-                                Serial.print("Capture initiated at ");
-                                Serial.print((char)('a' + c2));
-                                Serial.println(r2 + 1);
-                                
-                                // Store the target square and wait for the capturing piece to be placed there
-                                targetRow = r2;
-                                targetCol = c2;
-                                captureInProgress = true;
-                                
-                                // Flash the capture square to indicate waiting for piece placement
-                                boardDriver->setSquareLED(r2, c2, 255, 0, 0, 100);
-                                boardDriver->showLEDs();
-                                
-                                // Wait for the capturing piece to be placed
-                                bool capturePiecePlaced = false;
-                                while (!capturePiecePlaced) {
-                                    boardDriver->readSensors();
-                                    if (boardDriver->getSensorState(r2, c2)) {
-                                        capturePiecePlaced = true;
-                                        piecePlaced = true;
-                                        break;
-                                    }
-                                    delay(50);
-                                }
-                                break;
-                            }
-                            
-                            // For normal non-capture moves: detect when a piece is placed on an empty square
-                            else if (board[r2][c2] == ' ' && boardDriver->getSensorState(r2, c2) && !boardDriver->getSensorPrev(r2, c2)) {
-                                targetRow = r2;
-                                targetCol = c2;
-                                piecePlaced = true;
-                                break;
-                            }
-                        }
-                        if (piecePlaced || captureInProgress) break;
-                    }
-                    
-                    delay(50);
-                }
-
-                // Check if piece is replaced in the original spot
-                if (targetRow == row && targetCol == col) {
-                    Serial.println("Piece replaced in original spot");
-                    // Blink once to confirm
-                    boardDriver->setSquareLED(row, col, 0, 0, 0, 255);
-                    boardDriver->showLEDs();
-                    delay(200);
-                    boardDriver->setSquareLED(row, col, 0, 0, 0, 100);
-                    boardDriver->showLEDs();
-                    
-                    // Clear all LED effects
-                    boardDriver->clearAllLEDs();
-                    
-                    continue; // Skip to next iteration
-                }
-                
-                // Check if move is legal
-                bool legalMove = false;
-                bool isCapture = false;
-                for (int i = 0; i < moveCount; i++) {
-                    if (moves[i][0] == targetRow && moves[i][1] == targetCol) {
-                        legalMove = true;
-                        // Check if this is a capture move
-                        if (board[targetRow][targetCol] != ' ') {
-                            isCapture = true;
-                        }
-                        break;
-                    }
-                }
-                
-                if (legalMove) {
-                    Serial.print("Legal move to ");
-                    Serial.print((char)('a' + targetCol));
-                    Serial.println(targetRow + 1);
-                    
-                    // Play capture animation if needed
-                    if (board[targetRow][targetCol] != ' ') {
-                        Serial.println("Performing capture animation");
-                        boardDriver->captureAnimation();
-                    }
-                    
-                    // Process the move
-                    processMove(row, col, targetRow, targetCol, piece);
-                    
-                    // Check for pawn promotion
-                    checkForPromotion(targetRow, targetCol, piece);
-                    
-                    // Confirmation: Double blink destination square
-                    for (int blink = 0; blink < 2; blink++) {
-                        boardDriver->setSquareLED(targetRow, targetCol, 0, 0, 0, 255);
-                        boardDriver->showLEDs();
-                        delay(200);
-                        boardDriver->setSquareLED(targetRow, targetCol, 0, 0, 0, 50);
-                        boardDriver->showLEDs();
-                        delay(200);
+                        boardDriver->setSquareLED(r, c, 0, 0, 0, 50);
                     }
                 } else {
-                    Serial.println("Illegal move, reverting");
+                    boardDriver->setSquareLED(r, c, 255, 0, 0, 50); // Red = capture
                 }
-                
-                // Clear any remaining LED effects
-                boardDriver->clearAllLEDs();
             }
+            boardDriver->showLEDs();
+
+            // Wait for piece placement
+            int targetRow = -1, targetCol = -1;
+            bool piecePlaced = false;
+            bool captureInProgress = false;
+
+            while (!piecePlaced) {
+                boardDriver->readSensors();
+
+                // Returned to original square: cancel
+                if (boardDriver->getSensorState(row, col)) {
+                    targetRow = row; targetCol = col;
+                    piecePlaced = true;
+                    break;
+                }
+
+                for (int r2 = 0; r2 < 8 && !piecePlaced; r2++) {
+                    for (int c2 = 0; c2 < 8 && !piecePlaced; c2++) {
+                        if (r2 == row && c2 == col) continue;
+
+                        bool isLegalDest = false;
+                        for (int i = 0; i < moveCount; i++) {
+                            if (moves[i][0] == r2 && moves[i][1] == c2) { isLegalDest = true; break; }
+                        }
+                        if (!isLegalDest) continue;
+
+                        // Capture: enemy piece lifted from target
+                        if (board[r2][c2] != ' ' && !boardDriver->getSensorState(r2, c2) && boardDriver->getSensorPrev(r2, c2)) {
+                            Serial.print("Capture initiated at ");
+                            Serial.print((char)('a' + c2));
+                            Serial.println(r2 + 1);
+                            targetRow = r2; targetCol = c2;
+                            captureInProgress = true;
+                            boardDriver->setSquareLED(r2, c2, 255, 0, 0, 100);
+                            boardDriver->showLEDs();
+                            // Wait for capturing piece to be placed on target
+                            while (true) {
+                                boardDriver->readSensors();
+                                if (boardDriver->getSensorState(r2, c2)) {
+                                    piecePlaced = true;
+                                    break;
+                                }
+                                delay(50);
+                            }
+                            break;
+                        }
+
+                        // Quiet move: piece appeared on empty target
+                        if (board[r2][c2] == ' ' && boardDriver->getSensorState(r2, c2) && !boardDriver->getSensorPrev(r2, c2)) {
+                            targetRow = r2; targetCol = c2;
+                            piecePlaced = true;
+                            break;
+                        }
+                    }
+                }
+                delay(50);
+            }
+
+            // Cancelled (piece replaced)
+            if (targetRow == row && targetCol == col) {
+                Serial.println("Piece replaced - move cancelled");
+                boardDriver->clearAllLEDs();
+                boardDriver->updateSensorPrev();
+                return;
+            }
+
+            // Apply the move via the engine (handles castling rook, EP, state updates)
+            char promotedTo = 0;
+            if (chessEngine->isPawnPromotion(piece, targetRow)) {
+                Serial.println("Promotion! Choose your piece on the selector LEDs.");
+                boardDriver->promotionAnimation(targetCol);
+                promotedTo = askPromotionChoice(turnColor);
+                Serial.print("Promoted to: "); Serial.println(promotedTo);
+            }
+
+            bool wasCapture = (board[targetRow][targetCol] != ' ') ||
+                              chessEngine->isEnPassantMove(board, &state, row, col, targetRow, targetCol);
+            if (wasCapture) boardDriver->captureAnimation();
+
+            chessEngine->applyMove(board, &state, row, col, targetRow, targetCol, promotedTo);
+
+            // Confirmation: double blink dest
+            for (int b = 0; b < 2; b++) {
+                boardDriver->setSquareLED(targetRow, targetCol, 0, 0, 0, 255);
+                boardDriver->showLEDs();
+                delay(150);
+                boardDriver->setSquareLED(targetRow, targetCol, 0, 0, 0, 50);
+                boardDriver->showLEDs();
+                delay(150);
+            }
+            boardDriver->clearAllLEDs();
+
+            // Switch turn
+            turnColor = (turnColor == 'w') ? 'b' : 'w';
+
+            // Game over?
+            GameResult result = chessEngine->getGameResult(board, &state, turnColor);
+            if (result != GAME_ONGOING) {
+                announceGameResult(result);
+                gameOver = true;
+                boardDriver->updateSensorPrev();
+                return;
+            }
+
+            // Check announcement
+            if (chessEngine->isInCheck(board, turnColor)) {
+                Serial.print(turnColor == 'w' ? "White" : "Black");
+                Serial.println(" is in CHECK!");
+                blinkKingInCheck(turnColor);
+            }
+
+            boardDriver->updateSensorPrev();
+            return;
         }
     }
-    
-    // Update previous sensor state
+
     boardDriver->updateSensorPrev();
 }
 
 void ChessMoves::initializeBoard() {
-    for (int row = 0; row < 8; row++) {
-        for (int col = 0; col < 8; col++) {
+    for (int row = 0; row < 8; row++)
+        for (int col = 0; col < 8; col++)
             board[row][col] = INITIAL_BOARD[row][col];
-        }
-    }
 }
 
 void ChessMoves::waitForBoardSetup() {
     Serial.println("Waiting for pieces to be placed...");
     while (!boardDriver->checkInitialBoard(INITIAL_BOARD)) {
         boardDriver->updateSetupDisplay(INITIAL_BOARD);
-        boardDriver->printBoardState(INITIAL_BOARD);
-        delay(500);
+        delay(200);
     }
 }
 
 void ChessMoves::processMove(int fromRow, int fromCol, int toRow, int toCol, char piece) {
-    // Update board state
+    // Legacy entrypoint kept for compatibility; new code uses applyMove via engine.
     board[toRow][toCol] = piece;
     board[fromRow][fromCol] = ' ';
 }
 
 void ChessMoves::checkForPromotion(int targetRow, int targetCol, char piece) {
-    if (chessEngine->isPawnPromotion(piece, targetRow)) {
-        char promotedPiece = chessEngine->getPromotedPiece(piece);
-        
-        Serial.print((piece == 'P' ? "White" : "Black"));
-        Serial.print(" pawn promoted to Queen at ");
-        Serial.print((char)('a' + targetCol));
-        Serial.println((piece == 'P' ? "8" : "1"));
-        
-        // Play promotion animation
-        boardDriver->promotionAnimation(targetCol);
-        
-        // Promote to queen in board state
-        board[targetRow][targetCol] = promotedPiece;
-        
-        // Handle the promotion process
-        handlePromotion(targetRow, targetCol, piece);
-    }
+    // Legacy stub - promotion is now handled inline in update() before applyMove.
+    (void)targetRow; (void)targetCol; (void)piece;
 }
 
 void ChessMoves::handlePromotion(int targetRow, int targetCol, char piece) {
-    Serial.println("Please replace the pawn with a queen piece");
-    
-    // First wait for the pawn to be removed
-    while (boardDriver->getSensorState(targetRow, targetCol)) {
-        // Blink the square to indicate action needed
-        boardDriver->setSquareLED(targetRow, targetCol, 255, 215, 0, 50);
-        boardDriver->showLEDs();
-        delay(250);
-        boardDriver->setSquareLED(targetRow, targetCol, 0, 0, 0, 0);
-        boardDriver->showLEDs();
-        delay(250);
-        
-        // Read sensors
+    (void)targetRow; (void)targetCol; (void)piece;
+}
+
+// Show 4 selector LEDs in the back rank (a1/b1/c1/d1 for white,
+// a8/b8/c8/d8 for black) representing Q/R/B/N. The user places any
+// chess piece on the desired square. We pick the first sensor that
+// goes active among the four selector squares.
+char ChessMoves::askPromotionChoice(char color) {
+    int row = (color == 'w') ? 0 : 7;
+    // Light selector squares with distinct colors:
+    // a-file = Q (gold), b-file = R (red), c-file = B (blue), d-file = N (white)
+    boardDriver->clearAllLEDs();
+    boardDriver->setSquareLED(row, 0, 255, 215, 0,   0); // Q: gold
+    boardDriver->setSquareLED(row, 1, 255, 0,   0,   0); // R: red
+    boardDriver->setSquareLED(row, 2, 0,   0,   255, 0); // B: blue
+    boardDriver->setSquareLED(row, 3, 0,   0,   0,  255); // N: white
+    boardDriver->showLEDs();
+
+    // First flush the sensor state for these 4 squares
+    boardDriver->readSensors();
+    boardDriver->updateSensorPrev();
+
+    char selected = 0;
+    while (selected == 0) {
         boardDriver->readSensors();
+        // Pick the first selector that transitioned to active
+        for (int c = 0; c < 4; c++) {
+            if (boardDriver->getSensorState(row, c) && !boardDriver->getSensorPrev(row, c)) {
+                switch (c) {
+                    case 0: selected = (color == 'w') ? 'Q' : 'q'; break;
+                    case 1: selected = (color == 'w') ? 'R' : 'r'; break;
+                    case 2: selected = (color == 'w') ? 'B' : 'b'; break;
+                    case 3: selected = (color == 'w') ? 'N' : 'n'; break;
+                }
+                break;
+            }
+        }
+        boardDriver->updateSensorPrev();
+        delay(50);
     }
-    
-    Serial.println("Pawn removed, please place a queen");
-    
-    // Then wait for the queen to be placed
-    while (!boardDriver->getSensorState(targetRow, targetCol)) {
-        // Blink the square to indicate action needed
-        boardDriver->setSquareLED(targetRow, targetCol, 255, 215, 0, 50);
-        boardDriver->showLEDs();
-        delay(250);
-        boardDriver->setSquareLED(targetRow, targetCol, 0, 0, 0, 0);
-        boardDriver->showLEDs();
-        delay(250);
-        
-        // Read sensors
+
+    // Wait for the user to lift the selector piece off the menu so we
+    // don't immediately treat the next loop iteration as a 'move'.
+    while (boardDriver->getSensorState(row, 0) || boardDriver->getSensorState(row, 1) ||
+           boardDriver->getSensorState(row, 2) || boardDriver->getSensorState(row, 3)) {
         boardDriver->readSensors();
+        delay(50);
     }
-    
-    Serial.println("Queen placed, promotion complete");
-    
-    // Final confirmation blink
-    for (int i = 0; i < 3; i++) {
-        boardDriver->setSquareLED(targetRow, targetCol, 255, 215, 0, 50);
-        boardDriver->showLEDs();
-        delay(100);
-        boardDriver->setSquareLED(targetRow, targetCol, 0, 0, 0, 0);
-        boardDriver->showLEDs();
-        delay(100);
+    boardDriver->clearAllLEDs();
+    return selected;
+}
+
+void ChessMoves::announceGameResult(GameResult r) {
+    boardDriver->clearAllLEDs();
+    switch (r) {
+        case GAME_CHECKMATE_WHITE_WINS:
+            Serial.println("CHECKMATE - WHITE WINS");
+            // Light all white squares
+            for (int rr = 0; rr < 8; rr++)
+                for (int cc = 0; cc < 8; cc++)
+                    boardDriver->setSquareLED(rr, cc, 0, 0, 0, 255);
+            boardDriver->showLEDs();
+            break;
+        case GAME_CHECKMATE_BLACK_WINS:
+            Serial.println("CHECKMATE - BLACK WINS");
+            // Pulse red
+            for (int p = 0; p < 3; p++) {
+                for (int rr = 0; rr < 8; rr++)
+                    for (int cc = 0; cc < 8; cc++)
+                        boardDriver->setSquareLED(rr, cc, 255, 0, 0, 0);
+                boardDriver->showLEDs(); delay(300);
+                boardDriver->clearAllLEDs(); delay(300);
+            }
+            break;
+        case GAME_STALEMATE:
+            Serial.println("STALEMATE - Draw");
+            boardDriver->fireworkAnimation();
+            break;
+        case GAME_DRAW_50_MOVE:
+            Serial.println("DRAW - 50-move rule");
+            boardDriver->fireworkAnimation();
+            break;
+        case GAME_DRAW_INSUFFICIENT_MATERIAL:
+            Serial.println("DRAW - Insufficient material");
+            boardDriver->fireworkAnimation();
+            break;
+        default: break;
+    }
+    Serial.println("Reset the board (lift all pieces) to play again.");
+}
+
+void ChessMoves::blinkKingInCheck(char color) {
+    char target = (color == 'w') ? 'K' : 'k';
+    int kr = -1, kc = -1;
+    for (int r = 0; r < 8; r++)
+        for (int c = 0; c < 8; c++)
+            if (board[r][c] == target) { kr = r; kc = c; }
+    if (kr < 0) return;
+    for (int b = 0; b < 3; b++) {
+        boardDriver->setSquareLED(kr, kc, 255, 0, 0, 0);
+        boardDriver->showLEDs(); delay(150);
+        boardDriver->setSquareLED(kr, kc, 0, 0, 0, 0);
+        boardDriver->showLEDs(); delay(150);
     }
 }
 
 bool ChessMoves::isActive() {
-    return true; // Simple implementation for now
+    return !gameOver;
 }
 
 void ChessMoves::reset() {
     boardDriver->clearAllLEDs();
     initializeBoard();
+    state.reset();
+    turnColor = 'w';
+    gameOver = false;
 }

--- a/chess_moves.cpp
+++ b/chess_moves.cpp
@@ -53,7 +53,7 @@ void ChessMoves::update() {
                 
                 // Generate possible moves
                 int moveCount = 0;
-                int moves[28][2]; // up to 28 moves (maximum for a queen)
+                int moves[MAX_MOVES_PER_PIECE][2]; // sized via chess_engine.h constant
                 chessEngine->getPossibleMoves(board, row, col, moveCount, moves);
                 
                 // Light up current square and possible move squares

--- a/chess_moves.h
+++ b/chess_moves.h
@@ -17,6 +17,9 @@ private:
     
     // Internal board state for gameplay
     char board[8][8];
+    GameState state;
+    char turnColor; // 'w' or 'b'
+    bool gameOver;
     
     // Helper functions
     void initializeBoard();
@@ -24,6 +27,9 @@ private:
     void processMove(int fromRow, int fromCol, int toRow, int toCol, char piece);
     void checkForPromotion(int targetRow, int targetCol, char piece);
     void handlePromotion(int targetRow, int targetCol, char piece);
+    char askPromotionChoice(char color); // returns Q/R/B/N (uppercase if white, lowercase if black)
+    void announceGameResult(GameResult r);
+    void blinkKingInCheck(char color);
 
 public:
     ChessMoves(BoardDriver* bd, ChessEngine* ce);

--- a/stockfish_settings.h
+++ b/stockfish_settings.h
@@ -18,7 +18,7 @@ struct StockfishSettings {
     
     static StockfishSettings medium() {
         StockfishSettings s;
-        s.depth = 6;
+        s.depth = 10;
         s.timeoutMs = 25000;
         return s;
     }


### PR DESCRIPTION
## Summary

Substantial gameplay upgrade for the official Concept-Bytes firmware on **Arduino Nano RP2040 Connect**: full chess rules (check, checkmate, castling, en-passant, draws, promotion choice), sensor debounce, AP shutdown, and a 10-test on-boot validation suite. **+1107 / -282 lines, 9 files, 10/10 self-tests passing.**

Builds on top of:
- #9 — WiFi AP→STA fix (required for AI mode)
- #10 — 5 quality fixes (Stockfish parser, depth bug, etc.)

This PR depends on those landing first (or being squashed in together).

## What changes for the user

| Before | After |
|---|---|
| Pinned pieces could move and expose own king | Legal-move filter rejects them |
| No check / checkmate / stalemate display | King blinks red on check; full-board win/draw animations |
| No castling | Castling works (kingside + queenside, FIDE legal) |
| No en-passant | EP target highlighted pink, capture removes the right pawn |
| Pawn always auto-promoted to queen | Human vs Human: 4 LEDs let you pick Q/R/B/N. Bot mode: still auto-Q (Stockfish 'e7e8q' parsing TBD) |
| 50-move / insufficient material never end the game | Auto-detected, draw animation plays |
| Sensor flicker when sliding pieces | Debounce: 3 consecutive scans required to flip state |
| AP `OpenChessBoard` stays up forever | Shut down when entering Chess Moves / Sensor Test (~100 mA saved) |
| No way to know if firmware is broken | 10 self-tests at boot, red flash on failure |

## Engine architecture

New `ChessEngine` API, with `board[]` mutation centralised in `applyMove` so castling / EP / state updates can never be missed:

```cpp
struct GameState { castling rights; enPassant{Row,Col}; halfMoveClock; lastMove; };

void  ChessEngine::getLegalMoves(board, state, row, col, &count, moves);
bool  ChessEngine::isLegalMove(board, state, fromR, fromC, toR, toC);
bool  ChessEngine::isInCheck(board, color);
bool  ChessEngine::isSquareAttacked(board, row, col, byColor);
bool  ChessEngine::hasAnyLegalMove(board, state, color);
GameResult ChessEngine::getGameResult(board, state, colorToMove);
void  ChessEngine::applyMove(board, state, fromR, fromC, toR, toC, promoteTo=0);
int   ChessEngine::runSelfTests();
```

`getPossibleMoves` is kept as the pseudo-legal generator (no own-check filter); it's still used internally by `isSquareAttacked` and `getLegalMoves`.

## Self-tests (run at every boot)

```
=== ChessEngine self-tests ===
PASS T1: e2 pawn has 2 legal moves
PASS T2: b1 knight has 2 legal moves
PASS T3: no check at start
PASS T4: Fool's Mate detected
PASS T5: pinned rook stayed on file
PASS T6: both castlings legal
PASS T7: no castling in check
PASS T8: en-passant offered
PASS T9: K vs K is draw
PASS T10: kingside castle layout correct
=== Self-tests complete: 10/10 passed ===
```

These caught **one real bug during development** (a wrong test position that turned out to be a wrong test position rather than an engine bug — but the same pattern would catch a real regression).

## Sensor debounce

Each `readSensors()` call updates a per-square "stable count". A reading must repeat for **3 consecutive scans** before the public state flips. Tunable via `SENSOR_DEBOUNCE_SCANS` in [board_driver.h](board_driver.h).

This was visible in serial as flicker (`q` appearing/disappearing on d8 between scans during board setup) — gone now.

## AP shutdown

When entering Chess Moves or Sensor Test, `WiFi.end()` is called to release the radio. The `OpenChessBoard` AP was drawing ~100 mA continuously and creating a persistent WiFi network nobody uses once a mode is selected. Bot mode is **untouched** because PR #9 already does the AP teardown internally.

## Promotion choice (Human vs Human)

When a pawn reaches the back rank, four selector LEDs light up on the **player's own back rank** with distinct colours:
- a-file = **Q** (gold)
- b-file = **R** (red)
- c-file = **B** (blue)
- d-file = **N** (white)

Place any piece on one to choose. The selector then waits for you to lift the piece off the menu before re-arming the move detector.

Bot mode still auto-promotes to queen — the Stockfish API string `e7e8q` includes the promotion piece in its 5th character, but the existing `parseMove` only grabs the first 4 chars. That's a small follow-up, easy to bolt on but kept out of scope here to keep PR size manageable.

## Verification

```
Sketch uses 150679 bytes (0%) of program storage space.
Global variables use 44640 bytes (16%) of dynamic memory.
10/10 self-tests passed.
```

Tested on **Arduino Nano RP2040 Connect** with **WiFiNINA firmware 3.0.1**:
- Boot clean, self-tests pass before WiFi setup
- Game selection works as before
- Chess Moves Human-vs-Human plays through opening + check + castling
- Chess Bot Human-vs-AI: WiFi connects via #9 patch, Stockfish responds, validated bot moves applied via `applyMove`
- Sensor flicker on board setup is gone

## Trade-offs

- **Sketch +5963 bytes** vs the PR #10 baseline (still 0% of the 16 MB flash) and **+200 bytes RAM** for `GameState` instances and debounce buffers
- The on-boot animation on a self-test failure is intentionally noisy — it's better than silently corrupting a game
- Promotion choice in bot mode left as a follow-up (5-char move parsing)
- 3-fold repetition not yet implemented (would need position hashing + history; bigger memory hit)